### PR TITLE
expose the Timeout exception to the wrapped computation

### DIFF
--- a/Control/Concurrent/Timeout.hs
+++ b/Control/Concurrent/Timeout.hs
@@ -15,7 +15,7 @@
 -- Wait arbitrarily long for an IO computation to finish.
 -------------------------------------------------------------------------------
 
-module Control.Concurrent.Timeout ( timeout ) where
+module Control.Concurrent.Timeout ( Timeout, timeout, timeoutEx ) where
 
 
 -------------------------------------------------------------------------------
@@ -28,6 +28,7 @@ import Control.Exception        ( Exception, bracket, handleJust )
 import Control.Monad            ( return, (>>), fmap )
 import Data.Bool                ( otherwise )
 import Data.Eq                  ( Eq, (==) )
+import Data.Function            ( (.), const)
 import Data.Maybe               ( Maybe(Nothing, Just) )
 import Data.Ord                 ( (<) )
 import Data.Typeable            ( Typeable )
@@ -77,7 +78,12 @@ available within @n@ microseconds (@1\/10^6@ seconds). In case a result is
 available before the timeout expires, 'Just' @a@ is returned. A negative timeout
 interval means \"wait indefinitely\".
 
-The design of this combinator was guided by the objective that @timeout n f@
+If the computation has not terminated after @n@ microseconds, it is interrupted
+by an asynchronous exception. The value of this exception is also passed to @f@
+in advance. This enables the computation to detect whether it was interrupted by
+this timeout or some other exception.
+
+The design of this combinator was guided by the objective that @timeout n (const f)@
 should behave exactly the same as @f@ as long as @f@ doesn't time out. This
 means that @f@ has the same 'myThreadId' it would have without the timeout
 wrapper. Any exceptions @f@ might throw cancel the timeout and propagate further
@@ -99,9 +105,11 @@ they really don't because the runtime system uses scheduling mechanisms like
 @select(2)@ to perform asynchronous I\/O, so it is possible to interrupt
 standard socket I\/O or file I\/O using this combinator.
 -}
-timeout :: Integer -> IO α -> IO (Maybe α)
-timeout n f
-    | n < 0     = fmap Just f
+timeoutEx :: Integer -> (Timeout -> IO α) -> IO (Maybe α)
+timeoutEx n f
+    | n < 0     = do
+        ex <- fmap Timeout newUnique
+        fmap Just (f ex)
     | n == 0    = return Nothing
     | otherwise = do
         pid <- myThreadId
@@ -110,5 +118,11 @@ timeout n f
                    (\_ -> return Nothing)
                    (bracket (forkIO (delay n >> throwTo pid ex))
                             (killThread)
-                            (\_ -> fmap Just f)
+                            (\_ -> fmap Just (f ex))
                    )
+
+{-|
+Like 'timeoutEx', but does not expose the 'Timeout' exception to the called action.
+-}
+timeout :: Integer -> IO α -> IO (Maybe α)
+timeout n = timeoutEx n .  const


### PR DESCRIPTION
Implements basvandijk/unbounded-delays#5.