### PR TITLE
Bump lower bound of base package: GHC 7.0 is not supported

### DIFF
--- a/unbounded-delays.cabal
+++ b/unbounded-delays.cabal
@@ -25,7 +25,7 @@ source-repository head
   Location: git://github.com/basvandijk/unbounded-delays.git
 
 library
-  build-depends: base >= 4 && < 5
+  build-depends: base >= 4.4 && < 5
   exposed-modules: Control.Concurrent.Thread.Delay
                  , Control.Concurrent.Timeout
   ghc-options: -Wall


### PR DESCRIPTION
As witnessed by Hackage Matrix Builder (https://matrix.hackage.haskell.org/#/package/unbounded-delays) `unbounded-delays-0.1.1.0` and `unbounded-delays-0.1.0.10` no longer support GHC 7.0. I checked that GHC 7.2 is fine.

I'd appreciate Hackage revisions for both versions, because it poses certain difficulties for `bytestring` testing.