### PR TITLE
Use https instead of git:// for source url

### DIFF
--- a/unbounded-delays.cabal
+++ b/unbounded-delays.cabal
@@ -22,7 +22,7 @@ extra-source-files: README.markdown
 
 source-repository head
   Type: git
-  Location: git://github.com/basvandijk/unbounded-delays.git
+  Location: https://github.com/basvandijk/unbounded-delays.git
 
 library
   default-language: Haskell98


### PR DESCRIPTION
`git://` is no longer supported by GitHub (https://github.blog/2021-09-01-improving-git-protocol-security-github/)